### PR TITLE
Import headers, libraries and frameworks from OS X, Fink and MacPorts on Darwin only

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,4 @@
-import os, shutil
+import os, shutil, platform
 
 env = Environment()
 if env.GetOption('clean'):
@@ -9,6 +9,11 @@ if env.GetOption('clean'):
 else:
     print 'Generating gl3w...'
     execfile('gl3w_gen.py')
+
+if platform.system() == 'Darwin':
+    env.Append(CFLAGS=['-I/sw/include', '-I/opt/local/include', '-I/usr/X11/include'])
+    env.Append(LINKFLAGS=['-L/sw/lib', '-I/opt/local/lib'])
+    env.Append(FRAMEWORKS=['CoreFoundation'])
 
 env.Append(CFLAGS=['-Wall', '-O2'])
 env.Append(CPPPATH='include')


### PR DESCRIPTION
I've added some lines to SConstruct so that the project builds right away on OS X when Freeglut is installed on Fink or MacPorts, two oft-used third-party package managers on OS X. Also, I added the CoreFoundation Framework as a dependency as it is required for linking on OS X.
