### PR TITLE
Update everything to use new GL/glcorearb.h header.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,18 +9,18 @@ gl3w_ is the easiest way to get your hands on the functionality offered by
 OpenGL 3/4 core profile specification.
 
 Its main part is a simple gl3w_gen.py_ Python 2.6 script that downloads the
-Khronos_ supported gl3.h_ header and generates gl3w.h and gl3w.c from it. Those
-files can then be added and linked (statically or dynamically) into your
+Khronos_ supported glcorearb.h_ header and generates gl3w.h and gl3w.c from it.
+Those files can then be added and linked (statically or dynamically) into your
 project.
 
 Example
 -------
 
-Here is a simple example of using gl3w_ with glut. Note that GL3/gl3w.h must be
+Here is a simple example of using gl3w_ with glut. Note that GL/gl3w.h must be
 included before any other OpenGL related headers::
 
     #include <stdio.h>
-    #include <GL3/gl3w.h>
+    #include <GL/gl3w.h>
     #include <GL/glut.h>
 
     // ...
@@ -106,7 +106,7 @@ OpenGL_ is a registered trademark of SGI_.
 
 .. _gl3w: https://github.com/skaslev/gl3w
 .. _gl3w_gen.py: https://github.com/skaslev/gl3w/blob/master/gl3w_gen.py
-.. _gl3.h: http://www.opengl.org/registry/api/gl3.h
+.. _glcorearb.h: http://www.opengl.org/registry/api/glcorearb.h
 .. _OpenGL: http://www.opengl.org/
 .. _Khronos: http://www.khronos.org/
 .. _SGI: http://www.sgi.com/

--- a/gl3w_gen.py
+++ b/gl3w_gen.py
@@ -4,19 +4,19 @@ import os
 import urllib2
 
 # Create directories
-if not os.path.exists('include/GL3'):
-    os.makedirs('include/GL3')
+if not os.path.exists('include/GL'):
+    os.makedirs('include/GL')
 if not os.path.exists('src'):
     os.makedirs('src')
 
 # Download glcorearb.h
 if not os.path.exists('include/GL/glcorearb.h'):
-    print 'Downloading glcorearb.h to include/GL3...'
+    print 'Downloading glcorearb.h to include/GL...'
     web = urllib2.urlopen('http://www.opengl.org/registry/api/glcorearb.h')
     with open('include/GL/glcorearb.h', 'wb') as f:
         f.writelines(web.readlines())
 else:
-    print 'Reusing glcorearb.h from include/GL3...'
+    print 'Reusing glcorearb.h from include/GL...'
 
 # Parse function names from glcorearb.h
 print 'Parsing glcorearb.h header...'
@@ -34,8 +34,8 @@ def proc_t(proc):
              'p_t': 'PFN' + proc.upper() + 'PROC' }
 
 # Generate gl3w.h
-print 'Generating gl3w.h in include/GL3...'
-with open('include/GL3/gl3w.h', 'wb') as f:
+print 'Generating gl3w.h in include/GL...'
+with open('include/GL/gl3w.h', 'wb') as f:
     f.write(r'''#ifndef __gl3w_h_
 #define __gl3w_h_
 
@@ -72,7 +72,7 @@ void *gl3wGetProcAddress(const char *proc);
 # Generate gl3w.c
 print 'Generating gl3w.c in src...'
 with open('src/gl3w.c', 'wb') as f:
-    f.write(r'''#include <GL3/gl3w.h>
+    f.write(r'''#include <GL/gl3w.h>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN 1

--- a/src/test.c
+++ b/src/test.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <GL3/gl3w.h>
+#include <GL/gl3w.h>
 #ifdef __APPLE__
 #include <GLUT/glut.h>
 #else


### PR DESCRIPTION
Khronos changed GL3/gl3.h to GL/glcorearb.h with the release of GL 4.3. This updates everything as such. There's no more GL3 folder, as per the recommendation in the header to use GL/.
