### PR TITLE
Changed some types from void* to void(*)()

### DIFF
--- a/gl3w_gen.py
+++ b/gl3w_gen.py
@@ -52,7 +52,8 @@ extern "C" {
 /* gl3w api */
 int gl3wInit(void);
 int gl3wIsSupported(int major, int minor);
-void *gl3wGetProcAddress(const char *proc);
+typedef void gl3wProc();
+gl3wProc *gl3wGetProcAddress(const char *proc);
 
 /* OpenGL functions */
 ''')
@@ -90,13 +91,13 @@ static void close_libgl(void)
 	FreeLibrary(libgl);
 }
 
-static void *get_proc(const char *proc)
+static gl3wProc *get_proc(const char *proc)
 {
-	void *res;
+	gl3wProc *res;
 
-	res = wglGetProcAddress(proc);
+	res = (gl3wProc*) wglGetProcAddress(proc);
 	if (!res)
-		res = GetProcAddress(libgl, proc);
+		res = (gl3wProc*) GetProcAddress(libgl, proc);
 	return res;
 }
 #elif defined(__APPLE__) || defined(__APPLE_CC__)
@@ -121,9 +122,9 @@ static void close_libgl(void)
 	CFRelease(bundleURL);
 }
 
-static void *get_proc(const char *proc)
+static gl3wProc *get_proc(const char *proc)
 {
-	void *res;
+	gl3wProc *res;
 
 	CFStringRef procname = CFStringCreateWithCString(kCFAllocatorDefault, proc,
 		kCFStringEncodingASCII);
@@ -147,9 +148,9 @@ static void close_libgl(void)
 	dlclose(libgl);
 }
 
-static void *get_proc(const char *proc)
+static gl3wProc *get_proc(const char *proc)
 {
-	void *res;
+	gl3wProc *res;
 
 	res = glXGetProcAddress((const GLubyte *) proc);
 	if (!res)
@@ -194,7 +195,7 @@ int gl3wIsSupported(int major, int minor)
 	return version.major >= major;
 }
 
-void *gl3wGetProcAddress(const char *proc)
+gl3wProc *gl3wGetProcAddress(const char *proc)
 {
 	return get_proc(proc);
 }


### PR DESCRIPTION
This removes the illegal conversion between object pointers and function pointers.
Introduced a typedef for clarity.

For Windows, conversion from PROC to void(*)() appears to need a cast.

This fix isn't and can't be backward compatible.
