### PR TITLE
build test, forward compatible context init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
+option(BUILD_TESTS "build test examples" OFF)
+
 project(gl3w)
 
 include_directories(include)
@@ -9,3 +11,19 @@ add_library(gl3w src/gl3w.c)
 if (UNIX)
   target_link_libraries(gl3w dl)
 endif()
+
+if (BUILD_TESTS)
+  find_package(OpenGL REQUIRED)
+  find_package(GLUT REQUIRED)
+  
+  include_directories(${GLUT_INCLUDE_DIR})
+  
+  add_executable(gl3wtest
+    src/test.c
+    )
+  target_link_libraries(gl3wtest
+    gl3w
+    ${GLUT_glut_LIBRARY}
+    ${OPENGL_gl_LIBRARY}
+    )
+endif (BUILD_TESTS)

--- a/src/test.c
+++ b/src/test.c
@@ -5,6 +5,7 @@
 #include <GLUT/glut.h>
 #else
 #include <GL/glut.h>
+#include <GL/freeglut_ext.h>
 #endif
 
 static int width = 600, height = 600;
@@ -38,8 +39,12 @@ int main(int argc, char **argv)
 	unsigned mode = GLUT_RGBA | GLUT_DEPTH | GLUT_DOUBLE;
 #ifdef __APPLE__
 	mode |= GLUT_3_2_CORE_PROFILE;
-#endif
 	glutInitDisplayMode(mode);
+#else
+	glutInitDisplayMode(mode);
+        glutInitContextVersion (3, 2);
+        glutInitContextFlags(GLUT_FORWARD_COMPATIBLE);
+#endif
 	glutInitWindowSize(width, height);
 	glutCreateWindow("cookie");
 


### PR DESCRIPTION
build test option for cmake, query forward compatible context from freeglut (needed for mesa free drivers)