### PR TITLE
Update README.rst to document Python version requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,12 @@ Khronos_ supported glcorearb.h_ header and generates gl3w.h and gl3w.c from it.
 Those files can then be added and linked (statically or dynamically) into your
 project.
 
+Requirements
+------------
+
+gl3w_gen.py_ requires Python version 2.x (2.6 or higher) built with SSL
+support. It is not compatible with Python 3.x releases.
+
 Example
 -------
 


### PR DESCRIPTION
This PR adds a small "Requirements" section to the documentation, to make it clear which versions of Python can run the gl3w_gen.py script.

If https://github.com/skaslev/gl3w/pull/19 is accepted, this will need to be updated to reflect Python 3.x compatibility.

fixes #18