### PR TITLE
Update README to show Python 3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,12 @@ Khronos_ supported glcorearb.h_ header and generates gl3w.h and gl3w.c from it.
 Those files can then be added and linked (statically or dynamically) into your
 project.
 
+Requirements
+------------
+
+gl3w_gen.py_ requires Python version 2.6 or newer, with SSL support.
+It is also compatible with Python 3.x.
+
 Example
 -------
 


### PR DESCRIPTION
Adds a "Requirements" section to the README file to document the minimum supported version of Python.

fixes #18