### PR TITLE
Add a minimal example of using GLFW3 with GL3W

### DIFF
--- a/src/glfw_test.c
+++ b/src/glfw_test.c
@@ -1,0 +1,91 @@
+/*
+
+    This file is part of gl3w, hosted at https://github.com/skaslev/gl3w
+
+    This is free and unencumbered software released into the public domain.
+
+    Anyone is free to copy, modify, publish, use, compile, sell, or
+    distribute this software, either in source code form or as a compiled
+    binary, for any purpose, commercial or non-commercial, and by any
+    means.
+
+    In jurisdictions that recognize copyright laws, the author or authors
+    of this software dedicate any and all copyright interest in the
+    software to the public domain. We make this dedication for the benefit
+    of the public at large and to the detriment of our heirs and
+    successors. We intend this dedication to be an overt act of
+    relinquishment in perpetuity of all present and future rights to this
+    software under copyright law.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+    OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <GL/gl3w.h>
+#include <GLFW/glfw3.h>
+
+static int width = 600, height = 600;
+
+static float randf()
+{
+    return (float) rand() / ((float) RAND_MAX + 1);
+}
+
+static void display(GLFWwindow * window)
+{
+    glClearColor(randf(), randf(), randf(), 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glfwSwapBuffers(window);
+}
+
+static void reshape(GLFWwindow * window, int w, int h)
+{
+    width = w > 1 ? w : 1;
+    height = h > 1 ? h : 1;
+    glViewport(0, 0, width, height);
+    glClearDepth(1.0);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glEnable(GL_DEPTH_TEST);
+}
+
+int main(int argc, char **argv)
+{
+    glfwInit();
+
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+    GLFWwindow * window = glfwCreateWindow(width, height, "cookie", NULL, NULL);
+
+    glfwSetFramebufferSizeCallback(window, reshape);
+    glfwSetWindowRefreshCallback(window, display);
+
+    glfwMakeContextCurrent(window);
+
+    if (gl3wInit()) {
+        fprintf(stderr, "failed to initialize OpenGL\n");
+        return -1;
+    }
+    if (!gl3wIsSupported(3, 2)) {
+        fprintf(stderr, "OpenGL 3.2 not supported\n");
+        return -1;
+    }
+    printf("OpenGL %s, GLSL %s\n", glGetString(GL_VERSION),
+           glGetString(GL_SHADING_LANGUAGE_VERSION));
+
+    do {
+        display(window);
+        glfwPollEvents();
+    } while(!glfwWindowShouldClose(window));
+
+    glfwTerminate();
+    return 0;
+}


### PR DESCRIPTION
Add src/glfw_test.c as a minimal example of how to use GLFW3 with
GL3W. This is an (almost) direct translation of the existing file
src/test.c, which currently uses GLUT.

Tested on Debian 8.2 with GCC 4.9.2 and GLFW 3.1.1.

Issues that may need to be resolved before merging:

- Lack of build instructions. I compiled with the following:
  gcc -o glfw_test glfw_test.c gl3w.c -lglfw -lGL -ldl
  but this may need to change for other environments.

- Lack of error handling. I tried to keep the example minimal,
  which means not checking return values or defining a GLFW error
  callback. IMO it would be a good idea to add these.

- Limit framerate. It's one additional line to enable vsync,
  which would drastically reduce CPU usage in the example.

- Gotchas. Unlike GLUT, GLFW3 does not invoke the reshape callback
  for a window during creation. If the user is expecting this
  behaviour, it can lead to bugs. Maybe put some comments in to
  this effect?