### PR TITLE
gl3wInit returns 0 (false) when it fails

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ included before any other OpenGL related headers::
             glutMouseFunc(mouse);
             glutMotionFunc(motion);
 
-            if (gl3wInit()) {
+            if (!gl3wInit()) {
                     fprintf(stderr, "failed to initialize OpenGL\n");
                     return -1;
             }

--- a/README.rst
+++ b/README.rst
@@ -70,8 +70,8 @@ The gl3w_ API consists of just three functions:
 ``int gl3wInit(void)``
 
     Initializes the library. Should be called once after an OpenGL context has
-    been created. Returns ``0`` when gl3w_ was initialized successfully,
-    ``-1`` if there was an error.
+    been created. Returns ``1`` when gl3w_ was initialized successfully,
+    ``0`` if there was an error.
 
 ``int gl3wIsSupported(int major, int minor)``
 

--- a/gl3w_gen.py
+++ b/gl3w_gen.py
@@ -238,14 +238,14 @@ static struct {
 static int parse_version(void)
 {
 	if (!glGetIntegerv)
-		return -1;
+		return 0;
 
 	glGetIntegerv(GL_MAJOR_VERSION, &version.major);
 	glGetIntegerv(GL_MINOR_VERSION, &version.minor);
 
 	if (version.major < 3)
-		return -1;
-	return 0;
+		return 0;
+	return 1;
 }
 
 static void load_procs(void);


### PR DESCRIPTION
To match the logic that gl3wInit() works and the one used with gl3wIsSupported.
```(gl3wInit)``` worked, OK
```(!gl3wInit)``` NO gl3wInit
When it fails we get it with ```if( !gl3wInit() )```.
```if NOT gl3Init(ialized) then do X```

The same logic is used in gl3wIsSupported.
```if( !gl2wIsSupported(5,5) then X``` 
```if NOT gl3wIsSupported then do X```

For the moment I dont know if this change breaks something and since there is no error code it seems clearer to me.