### PR TITLE
Move local variable definition to start of function

### DIFF
--- a/src/glfw_test.c
+++ b/src/glfw_test.c
@@ -58,12 +58,14 @@ static void reshape(GLFWwindow * window, int w, int h)
 
 int main(int argc, char **argv)
 {
+    GLFWwindow * window;
+
     glfwInit();
 
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
-    GLFWwindow * window = glfwCreateWindow(width, height, "cookie", NULL, NULL);
+    window = glfwCreateWindow(width, height, "cookie", NULL, NULL);
 
     glfwSetFramebufferSizeCallback(window, reshape);
     glfwSetWindowRefreshCallback(window, display);


### PR DESCRIPTION
In C the convention is to define all local variables at the top of their containing scope. In the `glfw_test.c` example only one variable is used, but it is defined half-way through the `main` function. This PR moves it to the top of the scope.