### PR TITLE
Implement INTERFACE library CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,77 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1.3 FATAL_ERROR)
 
 project(gl3w)
 
-include_directories(include)
+set(CMAKE_VERBOSE_MAKEFILE false)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON) # -fPIC
 
-add_library(gl3w src/gl3w.c)
+set(SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/src)
+set(HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
 
-if (UNIX)
-  target_link_libraries(gl3w dl)
-endif()
+set(HEADER_FILES
+	"${HEADER_DIR}/GL/gl3w.h"
+	"${HEADER_DIR}/GL/glcorearb.h"
+)
 
-install(TARGETS gl3w ARCHIVE DESTINATION lib)
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION include)
+set(SOURCE_FILES
+	"${SOURCE_DIR}/gl3w.c"
+)
+
+# add and depend on OpenGL
+find_package(OpenGL REQUIRED)
+set(EXTERNAL_INCLUDE_DIRS ${EXTERNAL_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIR})
+set(EXTERNAL_LIBRARIES ${EXTERNAL_LIBRARIES} ${OPENGL_LIBRARIES})
+
+# add command to create the header and source files
+add_custom_command(
+	OUTPUT
+		"${SOURCE_DIR}/gl3w.c"
+		"${HEADER_DIR}/GL/gl3w.h"
+		"${HEADER_DIR}/GL/glcorearb.h"
+	COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/gl3w_gen.py
+	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gl3w_gen.py
+	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+# add pseudo target that depends on the generated files
+add_custom_target(
+	gl3w_gen ALL
+	DEPENDS
+		"${SOURCE_DIR}/gl3w.c"
+		"${HEADER_DIR}/GL/gl3w.h"
+		"${HEADER_DIR}/GL/glcorearb.h"
+)
+
+# create gl3w target
+add_library(${CMAKE_PROJECT_NAME} INTERFACE)
+
+# make gl3w target depend on the generator target
+add_dependencies(${CMAKE_PROJECT_NAME} gl3w_gen)
+
+# let remote project know about source and header files
+target_sources(${CMAKE_PROJECT_NAME} INTERFACE ${SOURCE_FILES})
+target_include_directories(${CMAKE_PROJECT_NAME} INTERFACE
+	$<BUILD_INTERFACE:${HEADER_DIR}>
+	$<INSTALL_INTERFACE:include>
+)
+target_include_directories(${CMAKE_PROJECT_NAME} INTERFACE ${EXTERNAL_INCLUDE_DIRS})
+# let remote project know which libraries need to be linked
+target_link_libraries(${CMAKE_PROJECT_NAME} INTERFACE ${EXTERNAL_LIBRARIES} dl)
+
+set(MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+set(BUILD_CMAKE_DIR "${CMAKE_CURRENT_BINARY_DIR}/cmake")
+
+# export targets for remote projects (i.e. make find_package(gl3w) work)
+configure_file(
+	"${MODULE_PATH}/${CMAKE_PROJECT_NAME}-config.cmake"
+	"${BUILD_CMAKE_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
+	COPYONLY
+)
+
+export(
+	TARGETS ${CMAKE_PROJECT_NAME}
+	FILE "${BUILD_CMAKE_DIR}/${CMAKE_PROJECT_NAME}-targets.cmake"
+)
+
+export(PACKAGE ${CMAKE_PROJECT_NAME})
+

--- a/cmake/gl3w-config.cmake
+++ b/cmake/gl3w-config.cmake
@@ -1,0 +1,2 @@
+include("${CMAKE_CURRENT_LIST_DIR}/gl3w-targets.cmake")
+


### PR DESCRIPTION
This is a comprehensive CMakeLists.txt for this project which I created for my personal use. I thought you might want it because the current CMakeLists.txt is far from ideal.

The usage is as simple as it is elegant. You can `make` this as usual which will generate the source files (.h and .c) and create `*config.cmake` and `*targets.cmake` files. These will then be automatically used by CMake and allow you to do the following in your project:

    find_project(gl3w REQUIRED)
    # ...
    add_executable(myapp foo.c bar.c)   # or add_library(), whatever
    target_link_libraries(myapp gl3w)   # <= this line is important

The last line will automatically include the gl3w headers, it will automatically link "myapp" to OpenGL (as the gl3w CMake pulls this dependency) and it will automatically compile `gl3w.c`.

Hope you find this useful. Thanks for gl3w!