### PR TITLE
Add FORWARD_COMPAT window hint to glfw_test.c

### DIFF
--- a/src/glfw_test.c
+++ b/src/glfw_test.c
@@ -65,6 +65,7 @@ int main(int argc, char **argv)
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE); /* Required for MacOS */
     window = glfwCreateWindow(width, height, "cookie", NULL, NULL);
 
     glfwSetFramebufferSizeCallback(window, reshape);


### PR DESCRIPTION
MacOS will only provide OpenGL 3.2 contexts that are forward-compatible (all deprecated features removed). The addition of this hint should allow the example to run on MacOS, while slightly restricting the feature set on other systems.

An alternative solution would be surrounding the hint with preprocessor guards that limit its inclusion to MacOS.

Fixes #42