### PR TITLE
Fixes #44, when project is added as a subdirectory to the root CMakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,35 +43,35 @@ add_custom_target(
 )
 
 # create gl3w target
-add_library(${CMAKE_PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME} INTERFACE)
 
 # make gl3w target depend on the generator target
-add_dependencies(${CMAKE_PROJECT_NAME} gl3w_gen)
+add_dependencies(${PROJECT_NAME} gl3w_gen)
 
 # let remote project know about source and header files
-target_sources(${CMAKE_PROJECT_NAME} INTERFACE ${SOURCE_FILES})
-target_include_directories(${CMAKE_PROJECT_NAME} INTERFACE
+target_sources(${PROJECT_NAME} INTERFACE ${SOURCE_FILES})
+target_include_directories(${PROJECT_NAME} INTERFACE
 	$<BUILD_INTERFACE:${HEADER_DIR}>
 	$<INSTALL_INTERFACE:include>
 )
-target_include_directories(${CMAKE_PROJECT_NAME} INTERFACE ${EXTERNAL_INCLUDE_DIRS})
+target_include_directories(${PROJECT_NAME} INTERFACE ${EXTERNAL_INCLUDE_DIRS})
 # let remote project know which libraries need to be linked
-target_link_libraries(${CMAKE_PROJECT_NAME} INTERFACE ${EXTERNAL_LIBRARIES} dl)
+target_link_libraries(${PROJECT_NAME} INTERFACE ${EXTERNAL_LIBRARIES} dl)
 
 set(MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(BUILD_CMAKE_DIR "${CMAKE_CURRENT_BINARY_DIR}/cmake")
 
 # export targets for remote projects (i.e. make find_package(gl3w) work)
 configure_file(
-	"${MODULE_PATH}/${CMAKE_PROJECT_NAME}-config.cmake"
-	"${BUILD_CMAKE_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
+	"${MODULE_PATH}/${PROJECT_NAME}-config.cmake"
+	"${BUILD_CMAKE_DIR}/${PROJECT_NAME}-config.cmake"
 	COPYONLY
 )
 
 export(
-	TARGETS ${CMAKE_PROJECT_NAME}
-	FILE "${BUILD_CMAKE_DIR}/${CMAKE_PROJECT_NAME}-targets.cmake"
+	TARGETS ${PROJECT_NAME}
+	FILE "${BUILD_CMAKE_DIR}/${PROJECT_NAME}-targets.cmake"
 )
 
-export(PACKAGE ${CMAKE_PROJECT_NAME})
+export(PACKAGE ${PROJECT_NAME})
 


### PR DESCRIPTION
In the commit da13943e39159a193c1192b2dedb6a41bba31d49, was created an interface, the motivation of which was to create a generator target, a command for generating sources and moving all generated sources to the binary folder.

However, those changes prevent using the project by including it as a subdirectory (Issue #44).

In this pull request, CMAKE_PROJECT_NAME replaced by PROJECT_NAME.
PROJECT_NAME - the name of the project set by PROJECT() command, while CMAKE_PROJECT_NAME the name of the first project set by the PROJECT() command, i.e. the top level project.
If gl3w was added to root project as a subdirectory, then CMAKE_PROJECT_NAME would have the name of the root project that caused CMake errors.

That is not the only issue. If the project is added as a subdirectory, then the generation of build files for root files fails, because the source **gl3w.c** is not generated yet. It is a chicken or the egg problem, I do not know how to solve it. As a temporary solution, I build gl3w and then run CMake for root project again.

I guess, it would be better, to have a switch, that would allow using the old logic.
