### PR TITLE
Helper scripts for configuration-time package generation

### DIFF
--- a/generate-and-find-package.txt
+++ b/generate-and-find-package.txt
@@ -1,0 +1,5 @@
+# Define GL3W_SOURCE_DIR in parent CMake script and then include this one to
+# generate gl3w files during configuration stage and find generated package
+
+include(${GL3W_SOURCE_DIR}/generate-package.txt)
+find_package(gl3w REQUIRED)

--- a/generate-package.txt
+++ b/generate-package.txt
@@ -1,0 +1,10 @@
+# Define GL3W_SOURCE_DIR in parent CMake script, then include this one to
+# generate gl3w files during configuration stage and then use
+# find_package(gl3w REQUIRED) to include generated gl3w files in project
+
+execute_process(
+    COMMAND cmake .
+    WORKING_DIRECTORY ${GL3W_SOURCE_DIR})
+execute_process(
+    COMMAND cmake --build .
+    WORKING_DIRECTORY ${GL3W_SOURCE_DIR})


### PR DESCRIPTION
Despite the fact that user is supposed to manually run `cmake .` in the gl3w folder to generate gl3w files prior to build system generation in their project, the process still can be automated by the means of CMake using [`execute_process`](https://cmake.org/cmake/help/v3.0/command/execute_process.html) to run `cmake` in the gl3w folder during configuration stage. But since @skaslev [asked here](https://github.com/skaslev/gl3w/pull/46#issuecomment-433813968), I've added a few scripts to encapsulate these additional steps.

With this patch user can get gl3w files generated during configuration stage:

`set(GL3W_SOURCE_DIR ThirdParty/gl3w)`
`include(${GL3W_SOURCE_DIR}/generate-package.txt)`
`find_package(gl3w REQUIRED)`
`target_link_libraries(foo gl3w)`

... or even:

`set(GL3W_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/gl3w)`
`include(${GL3W_SOURCE_DIR}/generate-and-find-package.txt)`
`target_link_libraries(foo gl3w)`