### PR TITLE
Fix WIN32_LEAN_AND_MEAN redefinition

### DIFF
--- a/gl3w_gen.py
+++ b/gl3w_gen.py
@@ -187,7 +187,9 @@ with open(os.path.join(args.root, 'src/gl3w.c'), 'wb') as f:
 #define ARRAY_SIZE(x)  (sizeof(x) / sizeof((x)[0]))
 
 #if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN 1
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1 // Exclude advanced Windows headers
+#endif // WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 static HMODULE libgl;


### PR DESCRIPTION
I encountered this little issue because I included `gl3w.c` as a header in the very end of `gl3w.h` because Visual Studio wanted every single `.c`/`.cpp` file to include my precompiled header. Since I included `gl3w.h` after including `Windows.h` (I define `WIN32_LEAN_AND_MEAN`), I got a macro redefinition. Most libraries do this - I was surprised that gl3w didn't. Here's a patch for the generator to add the `#ifdef` guard to the `#define WIN32_LEAN_AND_MEAN`.