### PR TITLE
Fix HTTP error 403 when downloading headers

### DIFF
--- a/gl3w_gen.py
+++ b/gl3w_gen.py
@@ -88,7 +88,7 @@ def download(url, dst):
         return
 
     print('Downloading {0}...'.format(dst))
-    web = urllib2.urlopen(url)
+    web = urllib2.urlopen(urllib2.Request(url, headers={'User-Agent': 'Mozilla/5.0'}))
     with open(dst, 'wb') as f:
         f.writelines(web.readlines())
 


### PR DESCRIPTION
The download function was throwing an HTTPError. The Khronos website rejected the request because of the default User-Agent in the header. Changing it to "Mozilla/5.0" fixes the issue.