### PR TITLE
Update Khronos registry URLs

### DIFF
--- a/gl3w_gen.py
+++ b/gl3w_gen.py
@@ -103,9 +103,9 @@ touch_dir(os.path.join(args.root, 'include/KHR'))
 touch_dir(os.path.join(args.root, 'src'))
 
 # Download glcorearb.h and khrplatform.h
-download('https://www.khronos.org/registry/OpenGL/api/GL/glcorearb.h',
+download('https://registry.khronos.org/OpenGL/api/GL/glcorearb.h',
          os.path.join(args.root, 'include/GL/glcorearb.h'))
-download('https://www.khronos.org/registry/EGL/api/KHR/khrplatform.h',
+download('https://registry.khronos.org/EGL/api/KHR/khrplatform.h',
          os.path.join(args.root, 'include/KHR/khrplatform.h'))
 
 # Parse function names from glcorearb.h


### PR DESCRIPTION
This updates registry URLs so that we can download the header files.

```
curl https://www.khronos.org/registry/OpenGL/api/GL/glcorearb.h

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://registry.khronos.org/OpenGL/api/GL/glcorearb.h">here</a>.</p>
</body></html>
```