### PR TITLE
Fix typo in MinGW gcc related diagnostic pragma

### DIFF
--- a/gl3w_gen.py
+++ b/gl3w_gen.py
@@ -198,7 +198,7 @@ with open(os.path.join(args.root, 'src/gl3w.c'), 'wb') as f:
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignore "-Wcast-function-type"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 
 static HMODULE libgl;


### PR DESCRIPTION
Unfortunately there was a typo in the pragma I added in #83. It is fixed here.

Sorry for the inconvenience.